### PR TITLE
v0.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orve",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orve",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "style-object-to-css-string": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orve",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Оbject reactive library. mix of react and vue",
   "main": "built/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prettier": "prettier  --write ./src",
     "watch": "tsc --watch",
     "build": "tsc --build",
-    "test": "jest"
+    "test": "jest --watch"
   },
   "keywords": [
     "vue",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "prettier": "prettier  --write ./src",
     "watch": "tsc --watch",
     "build": "tsc --build",
-    "test": "jest --watch"
+    "testW": "jest --watch",
+    "test": "jest"
   },
   "keywords": [
     "vue",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,33 @@
-import { createApp } from "./package/dom/index";
-import { refL } from "./package/reactive/refL";
-import { ref } from "./package/reactive/ref";
-import { refC } from "./package/reactive/refC";
-import { watch } from "./package/reactive/watch";
-import { refO } from "./package/reactive/refO";
-import { refA } from "./package/reactive/refA";
-import { effect } from "./package/reactive/effect";
-import { oif } from "./package/reactive/oif"; 
-import { Orve, context } from "./package/default";
+export { createApp } from "./package/dom/index";
+export { refL } from "./package/reactive/refL";
+export { ref } from "./package/reactive/ref";
+export { refC } from "./package/reactive/refC";
+export { watch } from "./package/reactive/watch";
+export { refO } from "./package/reactive/refO";
+export { refA } from "./package/reactive/refA";
+export { effect } from "./package/reactive/effect";
+export { oif } from "./package/reactive/oif"; 
+export { Orve, context } from "./package/default";
 import { Node, Fragment } from "./package/jsx";
-export {
-  createApp,
-  refL,
-  ref,
-  refC,
-  watch,
-  refO,
-  refA,
-  effect,
-  Orve,
-  Node,
-  Fragment,
-  oif,
-  context
-};
+export { Node, Fragment } from "./package/jsx";
+export * from "./package/dom/root";
+// export {
+//   createApp,
+//   refL,
+//   ref,
+//   refC,
+//   watch,
+//   refO,
+//   refA,
+//   effect,
+//   Orve,
+//   Node,
+//   Fragment,
+//   oif,
+//   context
+// };
 
 export default {
-  ...Orve,
   Node,
   Fragment,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,36 @@
-export { createApp } from "./package/dom/index";
-export { refL } from "./package/reactive/refL";
-export { ref } from "./package/reactive/ref";
-export { refC } from "./package/reactive/refC";
-export { watch } from "./package/reactive/watch";
-export { refO } from "./package/reactive/refO";
-export { refA } from "./package/reactive/refA";
-export { effect } from "./package/reactive/effect";
-export { oif } from "./package/reactive/oif"; 
-export { Orve, context } from "./package/default";
+import { createApp } from "./package/dom/index";
+import { refL } from "./package/reactive/refL";
+import { ref } from "./package/reactive/ref";
+import { refC } from "./package/reactive/refC";
+import { watch } from "./package/reactive/watch";
+import { refO } from "./package/reactive/refO";
+import { refA } from "./package/reactive/refA";
+import { effect } from "./package/reactive/effect";
+import { oif } from "./package/reactive/oif"; 
+import { Orve, context } from "./package/default";
 import { Node, Fragment } from "./package/jsx";
-export { Node, Fragment } from "./package/jsx";
-export * from "./package/dom/root";
-// export {
-//   createApp,
-//   refL,
-//   ref,
-//   refC,
-//   watch,
-//   refO,
-//   refA,
-//   effect,
-//   Orve,
-//   Node,
-//   Fragment,
-//   oif,
-//   context
-// };
-
-export default {
+import { createAppRoot } from "./package/dom/root";
+export {
+  createApp,
+  refL,
+  ref,
+  refC,
+  watch,
+  refO,
+  refA,
+  effect,
+  Orve,
   Node,
   Fragment,
+  oif,
+  context,
+  createAppRoot
+};
+
+export default {
+  createApp,
+  ...Orve,
+  Node,
+  Fragment,
+  createAppRoot
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { refO } from "./package/reactive/refO";
 import { refA } from "./package/reactive/refA";
 import { effect } from "./package/reactive/effect";
 import { oif } from "./package/reactive/oif"; 
-import { Orve } from "./package/default";
+import { Orve, context } from "./package/default";
 import { Node, Fragment } from "./package/jsx";
 export {
   createApp,
@@ -21,7 +21,8 @@ export {
   Orve,
   Node,
   Fragment,
-  oif
+  oif,
+  context
 };
 
 export default {

--- a/src/package/default.ts
+++ b/src/package/default.ts
@@ -1,14 +1,25 @@
-const Orve: Record<string, unknown> = {
-  use: function(obj) {
-    if (!obj) {
+declare global {
+  interface Window {
+    Orve: Record<string, any>;
+  }
+}
+
+export interface Plugin {
+  setup: (obj: any) => void; 
+}
+
+const Orve: Record<string, any> = {
+  use: function(obj?: Plugin) {
+    if (obj === undefined) {
       console.error(`Error: \n "${obj}" not a plugin`);
       return;
     }
+
     if (obj.setup) {
       obj.setup(this);
     } else {
       Object.keys(obj).forEach((i) => {
-        this.context[i] = obj[i];
+        this.context[i] = (obj as Record<string, any>)[i];
       })
     }
   },
@@ -21,12 +32,6 @@ const addedInOrve = (key: string, value:unknown) => {
     Orve[key] = Object.assign(Orve[key], value)
   } else {
     Orve[key] = value;
-  }
-}
-
-declare global {
-  interface Window {
-    Orve: Record<string, unknown>;
   }
 }
 

--- a/src/package/default.ts
+++ b/src/package/default.ts
@@ -39,7 +39,12 @@ if (window !== undefined) {
   window.Orve = Orve;
 }
 
+function context() {
+  return Orve;
+}
+
 export {
   addedInOrve,
-  Orve
+  Orve,
+  context
 };

--- a/src/package/default.ts
+++ b/src/package/default.ts
@@ -1,6 +1,7 @@
 declare global {
   interface Window {
     Orve: Record<string, any>;
+    orve: Record<string, any>
   }
 }
 

--- a/src/package/dom/builder/children.ts
+++ b/src/package/dom/builder/children.ts
@@ -6,6 +6,7 @@ import { RefCProxy } from "../../reactive/type";
 import { isNodeBoolean } from "./validator";
 import { generationID } from "../../usedFunction/keyGeneration";
 import { checkerEffect } from "../mount/props";
+import { Effect } from "../../reactive/effect";
 
 enum ChildType {
   HTML = "HTML",
@@ -140,7 +141,7 @@ function parseChildren(
         }
 
         if (proxyType === ProxyType.Effect) {
-          const call = checkerEffect(item as Record<string, any>);
+          const call = checkerEffect(item as Effect);
 
           const [ res ] = parseChildren.call(this, [ call ], props, parent);
           return {

--- a/src/package/dom/builder/children.ts
+++ b/src/package/dom/builder/children.ts
@@ -8,6 +8,7 @@ import { generationID } from "../../usedFunction/keyGeneration";
 import { checkerEffect } from "../mount/props";
 import { Effect } from "../../reactive/effect";
 
+
 enum ChildType {
   HTML = "HTML",
   Static = "Static",

--- a/src/package/dom/builder/children.ts
+++ b/src/package/dom/builder/children.ts
@@ -41,7 +41,7 @@ function parseChildren(
 ) {
   if (ar.length > 0) {
     if (isHaveAnyArray(ar)) ar = ar.flat(1);
-    return ar.map((item: unknown) : any => {
+    return ar.map((item: any): any => {
       const typeNode = typeOf(item);
 
       // NOTE if html code
@@ -119,10 +119,10 @@ function parseChildren(
         }
 
         if (proxyType === ProxyType.RefA) {
-          let list = (item as any).value;
+          let list: any[] = item.value;
 
-          if ((item as any).renderFunction !== null) {
-            list = list.map((item as any).renderFunction);
+          if (item.renderFunction !== null) {
+            list = list.map(item.renderFunction);
           }
 
           return {

--- a/src/package/dom/builder/error.ts
+++ b/src/package/dom/builder/error.ts
@@ -1,7 +1,7 @@
 import { message } from "./erMessage";
 
 class error extends Error {
-  constructor(message) {
+  constructor(message: string) {
     super(message);
     this.name = "orve - DOM builder -> parser";
   }

--- a/src/package/dom/builder/index.ts
+++ b/src/package/dom/builder/index.ts
@@ -53,10 +53,11 @@ function parser(
   const typeNode = typeOf(Node);
 
   if (typeNode !== "object") {
-    er(`component: ${String(component).substring(0, 50)}... \n${m.CALL_NODE_RETURN_NOT_A_OBJECT}`);
+    console.warn(`component: ${String(component).substring(0, 50)}... \n${m.CALL_NODE_RETURN_NOT_A_OBJECT}`);
+    return undefined;
   }
 
-  let node: Node = Node as Node;
+  let node: Node | undefined = Node as Node;
 
   if (node.child && !Array.isArray(node.child)) {
     node["child"] = [ node.child ];
@@ -67,6 +68,10 @@ function parser(
 
   if (typeof node.tag === "function") {
     node = recursiveTag.call(this, node);
+  }
+
+  if (node === undefined) {
+    return undefined;
   }
 
   const oNode: ONode = {

--- a/src/package/dom/builder/index.ts
+++ b/src/package/dom/builder/index.ts
@@ -8,7 +8,6 @@ import { ProxyType } from "../../reactive/type";
 import { generationID } from "../../usedFunction/keyGeneration";
 import { Node } from "../../jsx";
 
-
 type ComponentType = Record<string, any> | ((args?: Record<string, any>) => any);
 function prepareComponent(component: ComponentType): (() => any) {
   let comp: Record<string, any> | ((args?: Record<string, any>) => any) = component;
@@ -31,7 +30,6 @@ function parser(
 ) {
   // if app = {} or proxy;
   const component: ((args?: Record<string, any>) => any) = prepareComponent(app) as (() => any);
-
   let Node: Node | unknown = null;
 
   try {

--- a/src/package/dom/builder/index.ts
+++ b/src/package/dom/builder/index.ts
@@ -1,77 +1,108 @@
-import { ONode, ONodeOrve, TypeNode, Props } from "../types";
+import { ONode, TypeNode, Props } from "../types";
 import er, { message as m } from "./error";
 import { typeOf } from "../../usedFunction/typeOf";
 import { isONode } from "../builder/validator";
 import { parseChildren } from "./children";
 import { recursiveTag } from "./recursiveTag";
-import { RefLProxy, ProxyType } from "../../reactive/type";
+import { ProxyType } from "../../reactive/type";
 import { generationID } from "../../usedFunction/keyGeneration";
+import { Node } from "../../jsx";
+
+
+type ComponentType = Record<string, any> | ((args?: Record<string, any>) => any);
+function prepareComponent(component: ComponentType): (() => any) {
+  let comp: Record<string, any> | ((args?: Record<string, any>) => any) = component;
+  const typeComp = typeof comp;
+  if (typeComp !== "function") {
+    if (typeComp === "object") {
+      comp = () => component;
+    } else {
+      er(m.APP_NOT_A_FUNCTION_OR_OBJECT);
+    }
+  }
+  return comp as (() => any);
+}
+
 
 function parser(
-  app: () => unknown | ONode,
-  props: Props = null,
-  parent: ONodeOrve = null,
+  app: () => any | Record<string, any>,
+  props: Props | null = null,
+  parent: ONode | null = null,
 ) {
   // if app = {} or proxy;
-  let component = app;
-  const tComponent = typeof component;
-  if (tComponent !== "function")
-    if (tComponent === "object") component = () => app;
-    else er(m.APP_NOT_A_FUNCTION_OR_OBJECT);
-  const Node: ONode | unknown = props
+  const component: ((args?: Record<string, any>) => any) = prepareComponent(app) as (() => any);
+
+  let Node: Node | unknown = null;
+
+  try {
+    Node = props
     ? component.call(this, props)
     : component.call(this);
+  } catch(error) {
+    console.error(`${String(component).substring(0, 50)}... - ${error}`);
+  } 
+
+  if (component === null) {
+    // TODO В зависимости от env отображать или нет это сообщение.
+    Node = {
+      tag: "span",
+      child: [` ERROR WITH COMPONENT - ${String(component).substring(0, 50)}... `]
+    }
+  }
+
   const typeNode = typeOf(Node);
 
   if (typeNode !== "object") {
-    er(`component: ${component} \n${m.CALL_NODE_RETURN_NOT_A_OBJECT}`);
+    er(`component: ${String(component).substring(0, 50)}... \n${m.CALL_NODE_RETURN_NOT_A_OBJECT}`);
   }
 
-  let workObj: ONode = Node as ONode;
-  if (workObj.child && typeOf(workObj.child) !== "array") {
-    workObj["child"] = [workObj.child];
+  let node: Node = Node as Node;
+
+  if (node.child && !Array.isArray(node.child)) {
+    node["child"] = [ node.child ];
   }
 
   // check if node have all need key
-  isONode(workObj);
+  isONode(node);
 
-  if (typeof workObj.tag === "function") {
-    workObj = recursiveTag.call(this, workObj);
+  if (typeof node.tag === "function") {
+    node = recursiveTag.call(this, node);
   }
 
-  const newNode: ONodeOrve = {
-    ...workObj,
+  const oNode: ONode = {
+    ...node,
     node: null,
     keyNode: generationID(16),
     type: TypeNode.Component,
     parent: parent ? parent : null, 
   };
 
-  if (newNode.html) {
-    newNode.child = [newNode.html];
+
+  // NOTE возможно будут проблемы с этим куском.
+  if (oNode.html) {
+    oNode.child = [ oNode.html ];
   }
 
   // NOTE work with CHILD
-  if (newNode.child) {
-    // work with child
-    newNode.child = parseChildren.call(this, newNode.child, props, newNode);
+  if (oNode.child) {
+    oNode.child = parseChildren.call(this, oNode.child, props, oNode);
   }
 
-  // hooks created
-  if (newNode.hooks && newNode.hooks.created) {
-    const toHook = Object.assign({}, newNode);
+  // NOTE hook created
+  if (oNode.hooks && oNode.hooks.created) {
+    const toHook = { ...oNode };
     delete toHook.child;
 
-    newNode.hooks.created({
+    oNode.hooks.created({
       context: this,
       oNode: toHook,
     });
   }
 
-  if (newNode.ref !== undefined) {
-    if (typeof newNode.ref === "object") {
-      const type = (newNode.ref as RefLProxy).type;
-      const typeProxy = (newNode.ref as RefLProxy).proxyType;
+  if (oNode.ref !== undefined) {
+    if (typeof oNode.ref === "object") {
+      const type = oNode.ref.type;
+      const typeProxy = oNode.ref.proxyType;
       if (
         type === undefined ||
         type !== ProxyType.Proxy ||
@@ -84,7 +115,7 @@ function parser(
       er(m.REFL_INSERT_NOT_A_PROXY);
     }
   }
-  return newNode;
+  return oNode;
 }
 
 export { parser };

--- a/src/package/dom/builder/recursiveTag.ts
+++ b/src/package/dom/builder/recursiveTag.ts
@@ -1,10 +1,10 @@
-import { ONodeOrve, Props, ONode } from "../types";
 import { typeOf } from "../../usedFunction/typeOf";
 import er, { message as m } from "./error";
 import { isONode } from "../builder/validator";
+import { Node } from "../../jsx";
 
-function recursiveTag(node: ONodeOrve) {
-  let pr: Props = {};
+function recursiveTag(node: Node) : Node {
+  let pr: Record<string, any> = {};
 
   if (node.props) {
     pr = node.props;
@@ -14,11 +14,11 @@ function recursiveTag(node: ONodeOrve) {
     pr["children"] = node.child;
   }
 
-  let req: ONode;
+  let req: Node;
   if (Object.keys(pr).length > 0) {
-    req = (node.tag as () => ONode).call(this, pr);
+    req = (node.tag as (args?: Record<string, any>) => any).call(this, pr);
   } else {
-    req = (node.tag as () => ONode).call(this);
+    req = (node.tag as (args?: Record<string, any>) => any).call(this);
   }
 
   if (typeOf(req) !== "object") {

--- a/src/package/dom/builder/recursiveTag.ts
+++ b/src/package/dom/builder/recursiveTag.ts
@@ -13,7 +13,7 @@ function recursiveTag(node: Node) : Node | undefined {
   if (node.child) {
     pr["children"] = node.child;
   }
-
+  
   let req: Node;
   if (Object.keys(pr).length > 0) {
     req = (node.tag as (args?: Record<string, any>) => any).call(this, pr);

--- a/src/package/dom/builder/recursiveTag.ts
+++ b/src/package/dom/builder/recursiveTag.ts
@@ -18,7 +18,7 @@ function recursiveTag(node: Node) : Node {
   if (Object.keys(pr).length > 0) {
     req = (node.tag as (args?: Record<string, any>) => any).call(this, pr);
   } else {
-    req = (node.tag as (args?: Record<string, any>) => any).call(this);
+    req = (node.tag as (args?: Record<string, any>) => any).call(this, {});
   }
 
   if (typeOf(req) !== "object") {

--- a/src/package/dom/builder/recursiveTag.ts
+++ b/src/package/dom/builder/recursiveTag.ts
@@ -1,9 +1,9 @@
 import { typeOf } from "../../usedFunction/typeOf";
-import er, { message as m } from "./error";
+import { message as m } from "./error";
 import { isONode } from "../builder/validator";
 import { Node } from "../../jsx";
 
-function recursiveTag(node: Node) : Node {
+function recursiveTag(node: Node) : Node | undefined {
   let pr: Record<string, any> = {};
 
   if (node.props) {
@@ -22,7 +22,8 @@ function recursiveTag(node: Node) : Node {
   }
 
   if (typeOf(req) !== "object") {
-    er(m.CALL_NODE_RETURN_NOT_A_OBJECT);
+    console.warn(`component: ${String(JSON.stringify(node)).substring(0, 50)}... \n${m.CALL_NODE_RETURN_NOT_A_OBJECT}`);
+    return undefined;
   }
 
   isONode(req);

--- a/src/package/dom/builder/validator.ts
+++ b/src/package/dom/builder/validator.ts
@@ -1,41 +1,42 @@
 import er, { message as m } from "./error";
 import { typeOf } from "../../usedFunction/typeOf";
 
-const keys = ["tag", "props", "child", "hooks", "key", "ref", "html"];
+const KEYS = ["tag", "props", "child", "hooks", "key", "ref", "html"];
 
-function isONode(workObj: object) {
-  Object.keys(workObj).forEach((key) => {
-    if (!keys.includes(key.toLowerCase())) {
-      er(`"${key}" - ${m.UNSUPPORTED_KEY_IN_OBJECT}`);
-    }
-  });
-
-  if (!workObj["tag"]) {
+function isONode(node: Record<string, any>) {
+  if (!node["tag"]) {
     er(m.MISSING_TAG);
   }
 
-  if (workObj["props"] && typeOf(workObj["props"]) !== "object") {
-    er(`${workObj["props"]} - ${m.PROPS_NOT_A_NEED_TYPE}`);
+  Object.keys(node).forEach((key) => {
+    if (!KEYS.includes(key.toLowerCase())) {
+      er(`${String(node).substring(0, 50)}... "${key}" - ${m.UNSUPPORTED_KEY_IN_OBJECT}`);
+    }
+  });
+
+  if (node["props"] && typeOf(node["props"]) !== "object") {
+    er(`${String(node).substring(0, 50)}... ${node["props"]} - ${m.PROPS_NOT_A_NEED_TYPE}`);
   }
 
   return true;
 }
 
-function isNodeBoolean(workObj: object) {
+function isNodeBoolean(node: Record<string, any>) {
+  if (!node["tag"]) {
+    return false;
+  }
+
+  if (node["props"] && typeOf(node["props"]) !== "object") {
+    return false;
+  }
+
   let checker = true;
-  Object.keys(workObj).forEach((key) => {
-    if (!keys.includes(key.toLowerCase())) {
+  Object.keys(node).forEach((key) => {
+    if (!KEYS.includes(key.toLowerCase())) {
       checker = false;
     }
   });
 
-  if (!workObj["tag"]) {
-    return false;
-  }
-
-  if (workObj["props"] && typeOf(workObj["props"]) !== "object") {
-    return false;
-  }
   return checker;
 }
 

--- a/src/package/dom/builder/validator.ts
+++ b/src/package/dom/builder/validator.ts
@@ -1,7 +1,7 @@
 import er, { message as m } from "./error";
 import { typeOf } from "../../usedFunction/typeOf";
 
-const KEYS = ["tag", "props", "child", "hooks", "key", "ref", "html"];
+const KEYS = ["tag", "props", "child", "hooks", "key", "ref", "html", "$refoparams"];
 
 function isONode(node: Record<string, any>) {
   if (!node["tag"]) {
@@ -10,7 +10,7 @@ function isONode(node: Record<string, any>) {
 
   Object.keys(node).forEach((key) => {
     if (!KEYS.includes(key.toLowerCase())) {
-      er(`${String(node).substring(0, 50)}... "${key}" - ${m.UNSUPPORTED_KEY_IN_OBJECT}`);
+      er(`${String(JSON.stringify(node)).substring(0, 50)}... "${key}" - ${m.UNSUPPORTED_KEY_IN_OBJECT}`);
     }
   });
 

--- a/src/package/dom/error.ts
+++ b/src/package/dom/error.ts
@@ -1,7 +1,7 @@
 import { message } from "./erMessage";
 
 class error extends Error {
-  constructor(message) {
+  constructor(message: string) {
     super(message);
     this.name = "orve - DOM builder";
   }

--- a/src/package/dom/helperBuilder.ts
+++ b/src/package/dom/helperBuilder.ts
@@ -1,0 +1,21 @@
+const createObjectContext = function (context: Record<string, any>): Record<string, any> {
+  const Context: Record<string, any> = {};
+
+  if (Object.keys(context).length > 0) {
+    Object.keys(context).forEach((keyContext: string) => {
+      if (typeof context[keyContext] === "object" && Object.keys(context[keyContext]).length > 0) {
+        Object.keys(context[keyContext]).forEach((key) => {
+          const kContext = key.startsWith("$") ? key : "$" + key;
+          Context[kContext] = context[keyContext][key];
+        })
+      }
+    })
+  } else {
+    return {};
+  }
+  return Context;
+};
+
+export {
+  createObjectContext
+}

--- a/src/package/dom/index.ts
+++ b/src/package/dom/index.ts
@@ -20,7 +20,7 @@ function createApp(app: App | (() => unknown)): createApp | undefined {
 
   if (type === "object") {
     const { App, ...context } = app as App;
-    const parsedContext = createObjectContext(context);
+    const parsedContext: Record<string, any> = createObjectContext(context);
     if (Object.keys(parsedContext).length > 0) {
       Object.keys(parsedContext).forEach((key) => {
         Orve.context[key] = parsedContext[key];
@@ -41,7 +41,7 @@ function createApp(app: App | (() => unknown)): createApp | undefined {
 
   if (type === "function" || type === "object") {
     return {
-      mount: (root: string) => mount.bind(Orve)(root),
+      mount: (root: string) => mount(root),
     };
   }
 

--- a/src/package/dom/index.ts
+++ b/src/package/dom/index.ts
@@ -7,7 +7,7 @@ import { unmounted } from "./unmounted";
 
 // NOTE type
 
-interface createApp {
+export interface createApp {
   mount: (root: string) => void;
 };
 

--- a/src/package/dom/mount/child.ts
+++ b/src/package/dom/mount/child.ts
@@ -92,6 +92,7 @@ export const childF = function (
         const items = childF.call(this, tag, (item as any).value);
         item.value = items;
         (item as any).proxy.render = items;
+        (item as any).proxy.parentNode = (item as any).parent;
         return item;
       } else {
         const comment = document.createComment(

--- a/src/package/dom/mount/child.ts
+++ b/src/package/dom/mount/child.ts
@@ -7,7 +7,7 @@ import { message as m } from "./error";
 import { parseChildren } from "../builder/children";
 
 export const childF = function (
-  tag: HTMLElement,
+  tag: HTMLElement | null,
   nodes: Array<ONodeOrve | Child>,
 ): Array<ONodeOrve | Child | Array<ONodeOrve | Child>> {
   return nodes.map((item: ONodeOrve | Child) => {

--- a/src/package/dom/mount/error.ts
+++ b/src/package/dom/mount/error.ts
@@ -1,7 +1,7 @@
 import { message } from "./erMessage";
 
 class error extends Error {
-  constructor(message) {
+  constructor(message: string) {
     super(message);
     this.name = "orve - DOM builder -> mount";
   }

--- a/src/package/dom/mount/index.ts
+++ b/src/package/dom/mount/index.ts
@@ -19,7 +19,7 @@ function mount(query: string): void {
   Orve.tree = mountedNode.call(Orve.context, tag, oNode);
 }
 
-function createComment(app: HTMLElement | null, nodes: ONode ): ONode {
+function createComment(app: HTMLElement | null, nodes: ONode | any ): ONode {
   let text = "";
   if (nodes.child !== undefined && Array.isArray(nodes.child) && nodes.child.length > 0) {
     text = nodes.child.reduce((a: string, b: any) => {
@@ -38,6 +38,14 @@ function createComment(app: HTMLElement | null, nodes: ONode ): ONode {
     node: comment,
     type: TypeNode.Comment,
   } as ONode;
+
+  if (nodes["$refOParams"] !== undefined) {
+    const prop = nodes["$refOParams"].prop;
+    const indexF = nodes["$refOParams"].proxy.$reactiveParams.findIndex((x: Record<string, any>) => x.nameValue === prop);
+    if (indexF !== -1) {
+      nodes["$refOParams"].proxy.$reactiveParams[indexF].node = comment;
+    }
+  }
 
   if (app === null) return object;
 

--- a/src/package/dom/mount/index.ts
+++ b/src/package/dom/mount/index.ts
@@ -1,11 +1,9 @@
 import er, { message as m } from "./error";
-import { HookObject, ONode, TypeNode } from "../types";
+import { ONode, TypeNode } from "../types";
 import { propsF } from "./props";
 
 import { childF } from "./child";
 import { Child } from "../builder/children";
-
-import { RefLProxy } from "../../reactive/type";
 import { ChildType } from "../builder/children";
 
 import { Orve } from "../../default";

--- a/src/package/dom/mount/props.ts
+++ b/src/package/dom/mount/props.ts
@@ -1,20 +1,24 @@
 import reactToCSS from 'style-object-to-css-string';
-import { ProxyType } from "../../reactive/type";
+import { ProxyType, Proxy } from "../../reactive/type";
 import { PropsTypeRef, PropRef } from "../../reactive/ref";
 import e from "./error";
 
 import { typeOf } from "../../usedFunction/typeOf";
 
-type IMG = {
+interface IMG {
   default: string;
 };
 
-function checkerEffect(item) {
-  const call = (item as any).func();
-  if (call === undefined) {
-    e("Effect return undefined");
+function checkerEffect(item: Record<string, any>) {
+  if (item.func !== undefined) {
+    const call = item.func();
+    if (call === undefined) {
+      e("Effect return undefined");
+    }
+    return call;
+  } else {
+    e(`${item} not a effect`);
   }
-  return call;
 }
 
 export const propsF = function (
@@ -27,13 +31,13 @@ export const propsF = function (
   Object.keys(props).forEach((prop: string) => {
     if (prop === "src") {
       if (typeof props[prop] === "string") {
-        tag.setAttribute(prop, props[prop] as string);
-      } else if (typeOf(props[prop]) === "object") {
-        tag.setAttribute(prop, (props[prop] as IMG).default as string);
-      } else if ((typeOf(props[prop]) as string) === ProxyType.Proxy) {
-        const type = (props[prop] as any).proxyType;
+        tag.setAttribute(prop, String(props[prop]));
+      } else if (typeOf(props[prop]) === "object" && (props[prop] as Record<string, any>).default !== undefined) {
+        tag.setAttribute(prop, String((props[prop] as IMG).default));
+      } else if (typeOf(props[prop]) === ProxyType.Proxy) {
+        const type = (props[prop] as Proxy).proxyType;
         if (type === ProxyType.Effect) {
-          const call = checkerEffect(props[prop]);
+          const call = checkerEffect(props[prop] as Record<string, any>);
           (props[prop] as any).value = call;
 
           if (typeof call === "string") {
@@ -86,7 +90,7 @@ export const propsF = function (
         }
 
         if (type === ProxyType.Effect) {
-          const call = checkerEffect(props[prop]);
+          const call = checkerEffect(props[prop] as Record<string, any>);
 
           if (typeof call !== "function") {
             e("Effect in event return not a function");
@@ -129,7 +133,7 @@ export const propsF = function (
         }
 
         if (type === ProxyType.Effect) {
-          const call = checkerEffect(props[prop]);
+          const call = checkerEffect(props[prop] as Record<string, any>);
           let style = "";
           if (typeof call === "string") {
             style = call;
@@ -183,7 +187,7 @@ export const propsF = function (
         } as PropRef);
       }
       if (proxyType === ProxyType.Effect) {
-        const call = checkerEffect(props[prop]);
+        const call = checkerEffect(props[prop] as Record<string, any>);
 
         const type = typeOf(call);
 

--- a/src/package/dom/mount/style-object-to-css-string.d.ts
+++ b/src/package/dom/mount/style-object-to-css-string.d.ts
@@ -1,0 +1,1 @@
+declare module 'style-object-to-css-string';

--- a/src/package/dom/root.ts
+++ b/src/package/dom/root.ts
@@ -1,0 +1,24 @@
+import { createApp } from "./index";
+import er, { message } from "./error";
+import { Node, Fragment } from "../jsx";
+import {isONode} from "./builder/validator";
+
+export function createAppRoot(app: Node | unknown): createApp | undefined {
+  // orve Node and Fragment by hight level. (((
+  window.orve = { Node, Fragment };
+  if (Object.prototype.toString.call(app) !== '[object Object]') return;
+
+  const item: Node = app as Node;
+
+  if (!isONode(item)) {
+    er(message.UNSUPPORTED_TYPE_APP);
+    return;
+  }
+  
+  if (item.tag !== undefined && typeof item.tag === "function") {
+    const call = item.tag as (() => any);
+    return createApp(() => call());
+  }
+
+  return;
+}

--- a/src/package/dom/types.ts
+++ b/src/package/dom/types.ts
@@ -1,32 +1,11 @@
-type ONode = {
-  tag: string | (() => ONode);
-  props?: Record<string, any>;
-  child?:
-    | Array<() => ONode | string | number | object>
-    | string
-    | number
-    | object;
-  hooks?: Hooks;
-  keyNode: string;
-  ref?: object;
-};
+import { Node } from "../jsx";
 
-type ONodeOrve = {
-  tag: string | (() => ONode);
-  props?: Record<string, any>;
-  child?:
-    | Array<() => ONodeOrve | string | number | object>
-    | string
-    | number
-    | object;
-  hooks?: Hooks;
-  ref?: object;
+interface ONode extends Node {
   type: TypeNode;
   keyNode: string;
   node: null | HTMLElement | Comment;
-  parent: ONodeOrve | null;
-  html?: string
-};
+  parent: ONode | null;
+}
 
 enum HookObjectType {
   Child = "Child",
@@ -36,15 +15,8 @@ enum HookObjectType {
 
 type HookObject = {
   context: Record<string, any>;
-  oNode: ONodeOrve;
+  oNode: ONode;
   type?: HookObjectType;
-};
-
-type Hooks = {
-  created?: (_: HookObject) => void;
-  mounted?: (_: HookObject) => void;
-  updated?: (_: HookObject) => void;
-  unmounted?: () => void;
 };
 
 enum TypeNode {
@@ -54,10 +26,10 @@ enum TypeNode {
 
 type Props = {
   children?:
-    | Array<() => ONodeOrve | string | number | object>
+    | Array<() => ONode | string | number | object>
     | string
     | number
     | object;
 };
 
-export { ONode, ONodeOrve, TypeNode, Props, HookObject, HookObjectType };
+export { ONode, TypeNode, Props, HookObject, HookObjectType };

--- a/src/package/dom/unmounted.ts
+++ b/src/package/dom/unmounted.ts
@@ -1,0 +1,19 @@
+import { Node } from "./../jsx";
+import { Orve } from "../default";
+
+function unmounted(tree: Node): void {
+  if (tree.hooks !== undefined && tree.hooks.unmounted!== undefined) {
+    tree.hooks.unmounted({
+      context: Orve.Context,
+      oNode: tree
+    });
+  }
+
+  if (tree.child !== undefined && tree.child.length > 0) {
+    for (let i = 0; i !== tree.child.length; i++) {
+      unmounted(tree.child[i]);
+    }
+  }
+}
+
+export { unmounted }

--- a/src/package/jsx.ts
+++ b/src/package/jsx.ts
@@ -1,43 +1,60 @@
-type typeTag = {
-  tag: string | (() => typeTag),
-  hooks?: Record<string, () => void>,
-  props?: Record<string, unknown> | null,
-  child?: Array<typeTag>
+export type ArgProps = Record<string, any>;
+
+export interface Hooks {
+  created: () => void,
+  mounted: () => void,
+  updated: () => void,
+  unmounted: () => void
 }
 
-const Node = function(tag:string | (() => typeTag), props: Record<string, unknown> | null, ...child : any) {
-  const TAG: typeTag = {tag};
+export type TagType = string | ((arg?: ArgProps) => any);
 
-  if (props !== null) {
-    const finalProps = {};
-    Object.keys(props).forEach((key) => {
-      if (["o-hooks", "o-ref", "o-key", "o-props", "o-html"].includes(key)) {
-        const k = key.replace("o-", "").trim().toLowerCase();
-        if (key !== "o-props")
-          TAG[k] = props[key];
+export interface Node {
+  tag: TagType,
+  child?: any | any[],
+  props?: Record<string, any>,
+  ref?: any,
+  hooks?: Hooks,
+  html?: string
+}
+
+const O_KEY = ["o-hooks", "o-ref", "o-key", "o-html"];
+
+const Node = function(tag: TagType, props: Record<string, any> | null = null, ...child : any): Node {
+  const TAG: Node = { tag };
+
+  // parse props
+  if (props !== null && typeof props === "object") {
+    const PropsToTag: Record<string, any> = {};
+
+    const propsKeys = Object.keys(props);
+
+    propsKeys.forEach((prop) => {
+      if (O_KEY.includes(prop)) {
+        const parseKey: keyof Node = prop.toLowerCase().replace("o-", "") as keyof Node;
+        
+        TAG[parseKey] = props[prop];
       } else {
-        finalProps[key] = props[key];
+        PropsToTag[prop] = props[prop];
       }
     })
 
-    if (TAG.props !== undefined) {
-      TAG.props = {...finalProps, ...TAG.props};
-    } else {
-      TAG.props = finalProps;
+    if (Object.keys(propsKeys).length > 0) {
+      TAG.props = PropsToTag;
     }
-    
   }
 
+  // work with children
   if (child.length > 0) {
     TAG.child = child;
   }
   return TAG
 }
 
-const Fragment = function(tag:Record<string, unknown>) {
+const Fragment = function(tag: { children?: any | any[] } ): Node {
   return {
     tag: "fragment",
-    child: tag ? tag.children : []
+    child: tag !== undefined && tag.children !== undefined ? tag.children : []
   }
 }
 

--- a/src/package/jsx.ts
+++ b/src/package/jsx.ts
@@ -1,10 +1,15 @@
 export type ArgProps = Record<string, any>;
 
+
+export interface HooksContext {
+  context: Record<string, any>,
+  oNode: any
+}
 export interface Hooks {
-  created: () => void,
-  mounted: () => void,
-  updated: () => void,
-  unmounted: () => void
+  created: (arg: HooksContext) => void,
+  mounted: (arg: HooksContext) => void,
+  updated: (arg: HooksContext) => void,
+  unmounted: (arg: HooksContext) => void
 }
 
 export type TagType = string | ((arg?: ArgProps) => any);

--- a/src/package/reactive/effect.ts
+++ b/src/package/reactive/effect.ts
@@ -25,7 +25,7 @@ render = [
 */
 
 import e, { message as m } from "./error";
-import { ProxyType } from "./type";
+import { ProxyType, Proxy } from "./type";
 import { typeOf } from "../usedFunction/typeOf";
 import { PropsTypeRef } from "../reactive/ref";
 
@@ -99,23 +99,35 @@ function updated() {
 }
 
 function checkParent(item = null) {
-  const i = item === null ? this : item;
+  const i: Effect = item === null ? this : item;
 
   if (i.parent.length > 0) {
-    i.parent = i.parent.filter((e) => {
+    i.parent = i.parent.filter((e: any) => {
       if (e.type === PropsTypeRef.EffectChild) {
         if (document.body.contains(e.value.node)) {
           return true;
         }
-      } else if (PropsTypeRef[e.type] !== null) {
+      } else if (PropsTypeRef[(e as Parent).type] !== null) {
         if (document.body.contains(e.ONode.node)) {
           return true;
         }
       }
-
-
     })
   }
+}
+
+export interface Parent {
+  type: PropsTypeRef
+}
+
+export interface Effect extends Proxy {
+  value: any,
+  render: any[],
+  func: () => any,
+  parent: any[],
+  typeOutPut: any,
+  updated: () => undefined | void,
+  checkParent: () => void
 }
 
 function effect(func: () => any, dependencies: Array<any>) {
@@ -123,22 +135,22 @@ function effect(func: () => any, dependencies: Array<any>) {
     e(m.EFFECT_DECENCIES_NOT_A_ARRAY);
   }
 
-  const object = {
+  const object: Effect = {
     value: null,
     render: [],
     func,
     parent: [],
     typeOutPut: null,
     updated,
-    checkParent
+    checkParent,
+    type: ProxyType.Proxy,
+    proxyType: ProxyType.Effect
   };
 
   const proxy = new Proxy(object, {
-    get(target, prop) {
-      if (prop === "type") return ProxyType.Proxy;
-      if (prop === "proxyType") return ProxyType.Effect;
+    get(target: Effect, prop: keyof Effect | string) {
       if (prop in target) {
-        return target[prop];
+        return target[prop as keyof Effect];
       }
       return undefined;
     },

--- a/src/package/reactive/error.ts
+++ b/src/package/reactive/error.ts
@@ -1,7 +1,7 @@
 import { message } from "./erMessage";
 
 class error extends Error {
-  constructor(message) {
+  constructor(message: string) {
     super(message);
     this.name = "orve - reactive";
   }

--- a/src/package/reactive/refA.ts
+++ b/src/package/reactive/refA.ts
@@ -134,14 +134,16 @@ function createReactiveArray(ar: any[], object: RefAProxy) {
             // eslint-disable-next-line prefer-rest-params
             const args = arguments;
 
-            const newArgs = [];
+            if (object.render !== null) {
+              const newArgs = [];
 
-            for(let i = 0; i !== args.length; i++) {
-              newArgs.push(args[i]);
-            }
+              for(let i = 0; i !== args.length; i++) {
+                newArgs.push(args[i]);
+              }
 
-            for (let i = 0; i !== newArgs.length; i++) {
-              insertInArrayNewValue(object, t.length + i, newArgs[i]);
+              for (let i = 0; i !== newArgs.length; i++) {
+                insertInArrayNewValue(object, t.length + i, newArgs[i]);
+              }
             }
             updated(object);
             return Array.prototype[p].apply(t, args);
@@ -172,44 +174,46 @@ function createReactiveArray(ar: any[], object: RefAProxy) {
           return function (...args: number[]) {
             const deletedIndex = [];
 
-            for(let i = args[0]; i !== args[0] + args[1]; i++) {
-              deletedIndex.push(i);
-            }
-            if (deletedIndex.length > 0 && object.render !== null && object.render.length !== 0) {
-              deletedIndex.forEach((e) => {
-                if (object.render[e] !== undefined) {
-                  if (object.render.length === 1) {
-                    const comment = document.createComment(
-                      ` array ${object.keyNode} `,
-                    );
-                    object.render[0].node.replaceWith(comment);
-                    object.render = comment;
-                  } else {
-                    object.render[e].type = "DELETED";
-                  }
-                }
-              });
-              
-              if (Array.isArray(object.render)) {
-                let newRender: any = [];
-                const lastIndex = object.render.length - 1;
-
-                object.render.forEach((e, i) => {
-                  if (e.type !== "DELETED") {
-                    newRender.push(e);
-                  } else if (i === lastIndex && newRender.length === 0) {
-                    const comment = document.createComment(
-                      ` array ${object.keyNode} `,
-                    );
-                    e.node.replaceWith(comment);
-                    newRender = comment;
-                    object.empty = true;
-                  } else {
-                    e.node.remove();
+            if (object.render !== null) {
+              for(let i = args[0]; i !== args[0] + args[1]; i++) {
+                deletedIndex.push(i);
+              }
+              if (deletedIndex.length > 0 && object.render !== null && object.render.length !== 0) {
+                deletedIndex.forEach((e) => {
+                  if (object.render[e] !== undefined) {
+                    if (object.render.length === 1) {
+                      const comment = document.createComment(
+                        ` array ${object.keyNode} `,
+                      );
+                      object.render[0].node.replaceWith(comment);
+                      object.render = comment;
+                    } else {
+                      object.render[e].type = "DELETED";
+                    }
                   }
                 });
+                
+                if (Array.isArray(object.render)) {
+                  let newRender: any = [];
+                  const lastIndex = object.render.length - 1;
 
-                object.render = newRender;
+                  object.render.forEach((e, i) => {
+                    if (e.type !== "DELETED") {
+                      newRender.push(e);
+                    } else if (i === lastIndex && newRender.length === 0) {
+                      const comment = document.createComment(
+                        ` array ${object.keyNode} `,
+                      );
+                      e.node.replaceWith(comment);
+                      newRender = comment;
+                      object.empty = true;
+                    } else {
+                      e.node.remove();
+                    }
+                  });
+
+                  object.render = newRender;
+                }
               }
             }
 
@@ -227,10 +231,12 @@ function createReactiveArray(ar: any[], object: RefAProxy) {
       const s = Reflect.set(t, p, v);
       const num = parseInt(p, 10);
 
-      if (!Number.isNaN(num) && Array.isArray(object.render) && num < object.render.length) {
-        replaceArrayValue(object, num, v);
-      } else if (!Number.isNaN(num)) {
-        insertInArrayNewValue(object, num, v);
+      if (object.render !== null) {
+        if (!Number.isNaN(num) && Array.isArray(object.render) && num < object.render.length) {
+          replaceArrayValue(object, num, v);
+        } else if (!Number.isNaN(num)) {
+          insertInArrayNewValue(object, num, v);
+        }
       }
       updated(object);
       parentCall(object);

--- a/src/package/reactive/refA.ts
+++ b/src/package/reactive/refA.ts
@@ -270,6 +270,10 @@ function refA(ar: Array<any>) {
   return new Proxy(object, {
     set(t: RefAProxy, p: string, v: any) {
       if (p === "value") {
+        if (!Array.isArray(v)) {
+          console.error("refA wanted array");
+          return false;
+        }
         t.value = createReactiveArray(v, t);
         const render = t.render;
         if (render !== null && Array.isArray(render) && render.length > 0) {

--- a/src/package/reactive/refA.ts
+++ b/src/package/reactive/refA.ts
@@ -17,22 +17,22 @@ function updated(obj: any) {
   }
 }
 
-// function parentCall(obj: any) {
-//   if (obj.parent.length > 0) {
-//     obj.parent.forEach((item: any) => {
-//       if (item.type === ProxyType.Watch) {
-//         (item as any).value.updated(obj.value, undefined);
-//         return;
-//       }
-//       if (item.type === "Custom") {
-//         item.value(obj);
-//       }
-//       if (item.type === ProxyType.Effect || item.type === ProxyType.Oif) {
-//         item.value.updated();
-//       }
-//     });
-//   }
-// }
+function parentCall(obj: RefAProxy) {
+  if (obj.parent.length > 0) {
+    obj.parent.forEach((item: any) => {
+      if (item.type === ProxyType.Watch) {
+        (item as any).value.updated(obj.value, undefined);
+        return;
+      }
+      if (item.type === "Custom") {
+        item.value(obj);
+      }
+      if (item.type === ProxyType.Effect || item.type === ProxyType.Oif) {
+        item.value.updated();
+      }
+    });
+  }
+}
 
 function renderHelper(t: RefAProxy, p: number, v: any) {
   let replaceValue = v;
@@ -218,6 +218,7 @@ function createReactiveArray(ar: any[], object: RefAProxy) {
             return el;
           }
         }
+        parentCall(object);
         return val.bind(t);
       }
       return Reflect.get(t, p);
@@ -232,6 +233,7 @@ function createReactiveArray(ar: any[], object: RefAProxy) {
         insertInArrayNewValue(object, num, v);
       }
       updated(object);
+      parentCall(object);
       return s;
     }
   });

--- a/src/package/reactive/refA.ts
+++ b/src/package/reactive/refA.ts
@@ -1,21 +1,12 @@
 import e from "./error";
 
-import { ProxyType } from "./type";
+import { ProxyType, RefAProxy } from "./type";
 import { parseChildren } from "../dom/builder/children";
 import { childF } from "../dom/mount/child";
 import { HookObject } from "../dom/types";
 import { Orve } from "../default";
+import { generationID } from "../usedFunction/keyGeneration";
 // import { mountedNode } from "../dom/mount/index";
-
-
-interface RefA{
-  parent: any[],
-  value: any,
-  render: any,
-  empty: boolean,
-  renderFunction: (() => any) | null,
-  forList: () => this
-}
 
 function updated(obj: any) {
   if (obj.parentNode && obj.parentNode.hooks && obj.parentNode.hooks.updated) {
@@ -26,222 +17,305 @@ function updated(obj: any) {
   }
 }
 
-function parentCall(obj: any) {
-  if (obj.parent.length > 0) {
-    obj.parent.forEach((item: any) => {
-      if (item.type === ProxyType.Watch) {
-        (item as any).value.updated(obj.value, undefined);
-        return;
-      }
-      if (item.type === "Custom") {
-        item.value(obj);
-      }
-      if (item.type === ProxyType.Effect || item.type === ProxyType.Oif) {
-        item.value.updated();
-      }
-    });
+// function parentCall(obj: any) {
+//   if (obj.parent.length > 0) {
+//     obj.parent.forEach((item: any) => {
+//       if (item.type === ProxyType.Watch) {
+//         (item as any).value.updated(obj.value, undefined);
+//         return;
+//       }
+//       if (item.type === "Custom") {
+//         item.value(obj);
+//       }
+//       if (item.type === ProxyType.Effect || item.type === ProxyType.Oif) {
+//         item.value.updated();
+//       }
+//     });
+//   }
+// }
+
+function renderHelper(t: RefAProxy, p: number, v: any) {
+  let replaceValue = v;
+
+  if (t.renderFunction !== null) {
+    replaceValue = t.renderFunction(v, p);
   }
+  return replaceValue;
 }
 
-function newValueInsert(obj: Record<string, any>, value: any) {
-  let val = value;
+function replaceArrayValue(t: RefAProxy, p: number, v: any) {
+  const replaceValue = renderHelper(t, p, v);
 
-  if (obj.renderFunction !== null) {
-    const index = obj.value === null || obj.value.length === 0 ? 0: obj.value.length;
-    val = obj.renderFunction(val, index);
-  }
+  //const renderItem = t.render[p];
 
-  const newItem = parseChildren.call(
-    Orve.context,
-    Array.isArray(val) ? val : [val],
-    null,
-    obj.parentNode,
-    true,
-  );
+  const builderStep = parseChildren.call(Orve.context, [replaceValue], null, t.parentNode as any, true);
   
-  if (newItem[0].tag === "fragment") {
-    //const node = mountedNode(obj.parentNode.node, newItem[0]);
+  if (builderStep[0] === undefined) {
+    console.error("error build");
+    return;
+  }
+
+  const mounterStep = childF(null, builderStep);
+
+  if (mounterStep[0] === undefined) {
+    console.error("error mounted");
+    return;
+  }
+
+  const mounterItem = mounterStep[0];
+
+  if (t.render === null || t.render[p] === undefined) {
+    insertInArrayNewValue(t, p, v);
   } else {
-    const Item = childF.call(Orve.context, null, newItem);
-    if (!Array.isArray(obj.render)) {
-      obj.render.replaceWith(Item[0].node);
-      obj.render = Item;
-      obj.empty = false;
-      updated(obj);
+    t.render[p].node.replaceWith(mounterItem.node);
+    t.render[p] = mounterItem;
+    updated(t);
+  }
+}
+
+function insertInArrayNewValue(t: RefAProxy, p: number, v: any) {
+  const replaceValue = renderHelper(t, p, v);
+
+  const builderStep = parseChildren.call(Orve.context, [replaceValue], null, t.parentNode as any, true);
+  
+  if (builderStep[0] === undefined) {
+    console.error("error build");
+    return;
+  }
+
+  const mounterStep = childF(null, builderStep);
+
+  if (mounterStep[0] === undefined) {
+    console.error("error mounted");
+    return;
+  }
+
+  const mounterItem = mounterStep[0];
+
+  if (!Array.isArray(t.render)) {
+    t.render.replaceWith(mounterItem.node);
+    t.render = [mounterItem];
+    t.empty = false;
+    updated(t);
+  } else {
+    const element = t.render[t.render.length - 1].node;
+    element.after(mounterItem.node);
+    t.render.push(mounterItem);
+    updated(t);
+  }
+}
+
+function deletePartArrayByIndex(object: RefAProxy, index: number): void {
+  if (object.render !== null && object.render.length !== 0 && Array.isArray(object.render)) {
+    if (object.render.length === 1) {
+      const comment = document.createComment(
+        ` array ${object.keyNode} `,
+      );
+      object.render[0].node.replaceWith(comment);
+      object.render = comment;
     } else {
-      const element = obj.render[obj.render.length - 1].node;
-      element.after(Item[0].node);
-      obj.render.push(Item[0]);
-      updated(obj);
+      object.render[index].node.remove();
+      object.render[index] = undefined;
+    }
+
+    if (Array.isArray(object.render)) {
+      object.render = object.render.filter((x: any) => x !== undefined);
     }
   }
 }
 
-function replaceValue(obj: Record<string, any>, prop: string, value: any) {
-  let val = value;
+function createReactiveArray(ar: any[], object: RefAProxy) {
+  return new Proxy(ar, {
+    get(t: any[], p: any) {
+      const val = t[p];
+      if (typeof val === "function") {
+        if (['push', 'unshift'].includes(p)) {
+          return function () {
+            // eslint-disable-next-line prefer-rest-params
+            const args = arguments;
 
-  if (obj.renderFunction !== null) {
-    val = obj.renderFunction(value, parseInt(prop, 10));
-  }
+            const newArgs = [];
 
-  const newItem = parseChildren.call(
-    Orve.context,
-    Array.isArray(val) ? val : [val],
-    null,
-    obj.parentNode,
-    true,
-  );
-  const Item = childF.call(Orve.context, null, newItem);
-  obj.render[prop].node.replaceWith(Item[0].node);
-  obj.render[prop] = Item[0];
-  updated(obj);
-}
+            for(let i = 0; i !== args.length; i++) {
+              newArgs.push(args[i]);
+            }
 
-function checkOutAndInput(obj: Record<string, any>) {
-  if (
-    obj.value.length > 0 &&
-    Array.isArray(obj.render) &&
-    obj.value.length !== obj.render.length
-  ) {
-    let val = obj.value;
+            for (let i = 0; i !== newArgs.length; i++) {
+              insertInArrayNewValue(object, t.length + i, newArgs[i]);
+            }
+            updated(object);
+            return Array.prototype[p].apply(t, args);
+          }
+        }
+        if (['shift'].includes(p)) {
+          return function () {
+            deletePartArrayByIndex(object, 0);
 
-    if (obj.renderFunction !== null) {
-      if (Array.isArray(val)) {
-        val = val.map(obj.renderFunction);
-      } else {
-        console.log("asd");
+            // eslint-disable-next-line prefer-rest-params
+            const el = Array.prototype[p].apply(t, arguments);
+            updated(object);
+            return el;
+          }
+        }
+        if (['pop'].includes(p)) {
+          // последнего
+          return function () {
+            deletePartArrayByIndex(object, object.render.length - 1);
+
+            // eslint-disable-next-line prefer-rest-params
+            const el = Array.prototype[p].apply(t, arguments);
+            updated(object);
+            return el;
+          }
+        }
+        if (['splice'].includes(p)) {
+          return function (...args: number[]) {
+            const deletedIndex = [];
+
+            for(let i = args[0]; i !== args[0] + args[1]; i++) {
+              deletedIndex.push(i);
+            }
+            if (deletedIndex.length > 0 && object.render !== null && object.render.length !== 0) {
+              deletedIndex.forEach((e) => {
+                if (object.render[e] !== undefined) {
+                  if (object.render.length === 1) {
+                    const comment = document.createComment(
+                      ` array ${object.keyNode} `,
+                    );
+                    object.render[0].node.replaceWith(comment);
+                    object.render = comment;
+                  } else {
+                    object.render[e].type = "DELETED";
+                  }
+                }
+              });
+              
+              if (Array.isArray(object.render)) {
+                let newRender: any = [];
+                const lastIndex = object.render.length - 1;
+
+                object.render.forEach((e, i) => {
+                  if (e.type !== "DELETED") {
+                    newRender.push(e);
+                  } else if (i === lastIndex && newRender.length === 0) {
+                    const comment = document.createComment(
+                      ` array ${object.keyNode} `,
+                    );
+                    e.node.replaceWith(comment);
+                    newRender = comment;
+                    object.empty = true;
+                  } else {
+                    e.node.remove();
+                  }
+                });
+
+                object.render = newRender;
+              }
+            }
+
+            const el = Array.prototype[p].apply(t, args);
+            updated(object);
+            return el;
+          }
+        }
+        return val.bind(t);
       }
+      return Reflect.get(t, p);
+    },
+    set(t: any[], p: string, v: any) {
+      const s = Reflect.set(t, p, v);
+      const num = parseInt(p, 10);
+
+      if (!Number.isNaN(num) && Array.isArray(object.render) && num < object.render.length) {
+        replaceArrayValue(object, num, v);
+      } else if (!Number.isNaN(num)) {
+        insertInArrayNewValue(object, num, v);
+      }
+      updated(object);
+      return s;
     }
-
-    const newItem = parseChildren.call(
-      Orve.context,
-      val,
-      null,
-      obj.parentNode,
-      true,
-    );
-    const newRender = obj.render.map((ren: Record<string, any>, i: number) => {
-      if (newItem[i] === undefined) {
-        ren.node.remove();
-        return undefined;
-      }
-      return ren;
-    });
-    obj.render = newRender.filter((i: any) => i !== undefined);
-    updated(obj);
-  } else if (obj.value.length === 0 && Array.isArray(obj.render)) {
-    const element = document.createComment(` array ${obj.keyNode} `);
-    obj.render[0].node.replaceWith(element);
-    obj.render = element;
-    obj.empty = true;
-    updated(obj);
-  }
+  });
 }
 
 function refA(ar: Array<any>) {
   if (!Array.isArray(ar)) {
     e("refA - need array");
   }
-  const object: RefA = {
-    parent: [],
-    value: null,
-    render: null,
-    empty: true,
-    renderFunction: null,
-    forList: function(func = null){
+
+  const object: RefAProxy = {
+    parent: [], 
+    value: null, // proxy для массива
+    render: null, // все ноды которые на экране
+    empty: true, // пустой ли массив
+    renderFunction: null, // forList
+    forList: function(func = null) {
       if (func !== null && typeof func === "function") {
         this.renderFunction = func;
       } else {
         console.warn("* forList need function *");
       }
       return this;
-    } 
+    },
+    type: ProxyType.Proxy,
+    proxyType: ProxyType.RefA,
+    parentNode: null,
+    keyNode: generationID(8)
   };
 
-  let checkAr: any = null;
-  let mutationArray = false;
-  const array = new Proxy(ar, {
-    get(target, prop, r) {
-      if (prop === "constructor") {
-        mutationArray = true;
-        setTimeout(() => {
-          checkOutAndInput(object);
-          mutationArray = false;
-        }, 5);
-      }
-      const v = Reflect.get(target, prop, r);
-      return v;
-    },
-    set(target, prop, value) {
-      const isNum = parseInt(prop as string, 10);
-      if (
-        !Number.isNaN(isNum) &&
-        isNum < target.length &&
-        object.render !== null
-      ) {
-        replaceValue(object, prop as string, value);
-        if (mutationArray) {
-          if (checkAr !== null) clearTimeout(checkAr);
-          checkAr = setTimeout(() => {
-            checkOutAndInput(object);
-            mutationArray = false;
-          }, 1);
-        }
-      } else if (
-        !Number.isNaN(isNum) &&
-        isNum === target.length &&
-        object.render !== null
-      ) {
-        newValueInsert(object, value);
-      }
+  const array = createReactiveArray(ar, object);
 
-      const s = Reflect.set(target, prop, value);
-      parentCall(object);
-      return s;
-    },
-  });
-
-  object["value"] = array;
-  object["empty"] = array.length === 0;
+  object.value = array;
+  object.empty = array.length === 0;
 
   return new Proxy(object, {
-    get(target, prop) {
-      if (prop === "type") return ProxyType.Proxy;
-      if (prop === "proxyType") return ProxyType.RefA;
-      return Reflect.get(target, prop);
-    },
-    set(target, prop, value) {
-      if (prop === "value") {
-        if (target["value"].length === 0) {
-          value.forEach((e : any) => {
-            target["value"].push(e);
+    set(t: RefAProxy, p: string, v: any) {
+      if (p === "value") {
+        t.value = createReactiveArray(v, t);
+        const render = t.render;
+        if (render !== null && Array.isArray(render) && render.length > 0) {
+          const lastItem = render[render.length - 1];
+          render.forEach((e: any, i) => {
+            if (i !== render.length - 1) {
+              e.node.remove();
+              render[i] = undefined;
+            }
           });
-          return true;
-        } else {
-          if (value.length > target["value"].length) {
-            value.forEach((e: any, i: number) => {
-              if (target["value"][i] !== undefined) {
-                target["value"][i] = e;
+          object.render = lastItem.node;
+
+          const val = v.map((e: any, i: number) => {
+            return renderHelper(t, i, e);
+          })
+
+          const builderStep = parseChildren.call(Orve.context, val, null, t.parentNode as any, true);
+
+          if (builderStep.length === 0) {
+            console.error("bad work in value");
+          }
+
+          const mounterStep = childF(null, builderStep);
+
+          if (mounterStep.length > 0) {
+            mounterStep.forEach((e: any) => {
+              if (!Array.isArray(object.render)) {
+                object.render.replaceWith(e.node);
+                object.render = [ e ];
               } else {
-                target["value"].push(e);
+                const lastItem = object.render[object.render.length - 1].node;
+                lastItem.after(e.node);
+                object.render.push(e);
               }
             });
-          } else if (value.length < target["value"].length) {
-            target["value"].splice(0, target["value"].length);
-            value.forEach((e: any) => {
-              target["value"].push(e);
-            });
           }
-          return true;
         }
+        return true;
       }
-      return Reflect.set(target, prop, value);
+      return Reflect.set(t, p, v);
     },
     deleteProperty() {
       console.error("refA - You try to delete prop in ref");
       return false;
     },
-  });
+  })
 }
 
 export { refA };

--- a/src/package/reactive/refA.ts
+++ b/src/package/reactive/refA.ts
@@ -7,6 +7,16 @@ import { HookObject } from "../dom/types";
 import { Orve } from "../default";
 // import { mountedNode } from "../dom/mount/index";
 
+
+interface RefA{
+  parent: any[],
+  value: any,
+  render: any,
+  empty: boolean,
+  renderFunction: (() => any) | null,
+  forList: () => this
+}
+
 function updated(obj: any) {
   if (obj.parentNode && obj.parentNode.hooks && obj.parentNode.hooks.updated) {
     obj.parentNode.hooks.updated({
@@ -87,7 +97,7 @@ function replaceValue(obj: Record<string, any>, prop: string, value: any) {
   updated(obj);
 }
 
-function checkOutAndInput(obj) {
+function checkOutAndInput(obj: Record<string, any>) {
   if (
     obj.value.length > 0 &&
     Array.isArray(obj.render) &&
@@ -110,14 +120,14 @@ function checkOutAndInput(obj) {
       obj.parentNode,
       true,
     );
-    const newRender = obj.render.map((ren, i) => {
+    const newRender = obj.render.map((ren: Record<string, any>, i: number) => {
       if (newItem[i] === undefined) {
         ren.node.remove();
         return undefined;
       }
       return ren;
     });
-    obj.render = newRender.filter((i) => i !== undefined);
+    obj.render = newRender.filter((i: any) => i !== undefined);
     updated(obj);
   } else if (obj.value.length === 0 && Array.isArray(obj.render)) {
     const element = document.createComment(` array ${obj.keyNode} `);
@@ -132,11 +142,11 @@ function refA(ar: Array<any>) {
   if (!Array.isArray(ar)) {
     e("refA - need array");
   }
-  const object = {
+  const object: RefA = {
     parent: [],
     value: null,
     render: null,
-    empty: null,
+    empty: true,
     renderFunction: null,
     forList: function(func = null){
       if (func !== null && typeof func === "function") {
@@ -148,7 +158,7 @@ function refA(ar: Array<any>) {
     } 
   };
 
-  let checkAr = null;
+  let checkAr: any = null;
   let mutationArray = false;
   const array = new Proxy(ar, {
     get(target, prop, r) {
@@ -203,13 +213,13 @@ function refA(ar: Array<any>) {
     set(target, prop, value) {
       if (prop === "value") {
         if (target["value"].length === 0) {
-          value.forEach((e) => {
+          value.forEach((e : any) => {
             target["value"].push(e);
           });
           return true;
         } else {
           if (value.length > target["value"].length) {
-            value.forEach((e, i) => {
+            value.forEach((e: any, i: number) => {
               if (target["value"][i] !== undefined) {
                 target["value"][i] = e;
               } else {
@@ -218,7 +228,7 @@ function refA(ar: Array<any>) {
             });
           } else if (value.length < target["value"].length) {
             target["value"].splice(0, target["value"].length);
-            value.forEach((e) => {
+            value.forEach((e: any) => {
               target["value"].push(e);
             });
           }

--- a/src/package/reactive/refC.ts
+++ b/src/package/reactive/refC.ts
@@ -98,6 +98,7 @@ function refC(app: (() => any) | null = null) {
                     null,
                     item.parent,
                   );
+                  if (parsedItem === undefined) return;
                   const element: any = mountedNode.call(
                     Orve.context,
                     null,

--- a/src/package/reactive/refC.ts
+++ b/src/package/reactive/refC.ts
@@ -33,7 +33,7 @@ function checkExistParents(ar: any): any {
   return nArr;
 }
 
-function unmountedDep(tag) {
+function unmountedDep(tag: Record<string, any>) {
   if (tag.hooks && tag.hooks?.unmounted !== undefined) {
     tag.hooks.unmounted({
       context: Orve.context,
@@ -48,7 +48,7 @@ function unmountedDep(tag) {
   }
 }
 
-function refC(app: () => any | object | null = null) {
+function refC(app: (() => any) | null = null) {
   let block = app;
   if (app === null) {
     block = () => ({ tag: "comment", child: "refC" });
@@ -66,7 +66,7 @@ function refC(app: () => any | object | null = null) {
   } as RefCProxy;
 
   return new Proxy<RefCProxy>(object, {
-    get(target, prop) {
+    get(target: Record<string, any> , prop: keyof RefCProxy | string) {
       if (prop === "type") return ProxyType.Proxy;
       if (prop === "proxyType") return ProxyType.RefC;
       if (prop in target) {
@@ -98,7 +98,7 @@ function refC(app: () => any | object | null = null) {
                     null,
                     item.parent,
                   );
-                  const element = mountedNode.call(
+                  const element: any = mountedNode.call(
                     Orve.context,
                     null,
                     parsedItem,

--- a/src/package/reactive/refL.ts
+++ b/src/package/reactive/refL.ts
@@ -1,10 +1,12 @@
 import { ProxyType, RefLProxy } from "./type";
 
 function refL(): RefLProxy {
-  const object = {
+  const object: RefLProxy  = {
     parent: [],
     value: null,
-  } as RefLProxy;
+    type: ProxyType.Proxy,
+    proxyType: ProxyType.RefL
+  }
 
   return new Proxy<RefLProxy>(object, {
     set(target, prop, value) {
@@ -32,9 +34,7 @@ function refL(): RefLProxy {
       }
       return false;
     },
-    get(target, prop) {
-      if (prop === "type") return ProxyType.Proxy;
-      if (prop === "proxyType") return ProxyType.RefL;
+    get(target: RefLProxy, prop: keyof RefLProxy) {
       if (prop in target) {
         return target[prop];
       }

--- a/src/package/reactive/refO.ts
+++ b/src/package/reactive/refO.ts
@@ -4,9 +4,9 @@ import { typeOf } from "../usedFunction/typeOf";
 import { ProxyType } from "../reactive/type";
 import { refA } from "./refA";
 
-function updated(target) {
+function updated(target: Record<string, any>) {
   if (target.$parent.length > 0) {
-    target.$parent.forEach((item) => {
+    target.$parent.forEach((item: any) => {
       if (item.type === ProxyType.Watch) {
         const i = Object.assign({}, target);
         delete i["$parent"];
@@ -27,13 +27,13 @@ function updated(target) {
 }
 
 function refO(object: any) {
-  const obj = {
+  const obj : RefOProxy = {
     $parent: [],
-  } as RefOProxy;
+    type: ProxyType.Proxy,
+    proxyType: ProxyType.RefO
+  };
   const mainProxy = new Proxy<RefOProxy>(obj, {
-    get(target, prop) {
-      if (prop === "type") return ProxyType.Proxy;
-      if (prop === "proxyType") return ProxyType.RefO;
+    get(target: Record<string, any>, prop: string) {
       if (prop === "updated") {
         updated(target);
       }
@@ -42,7 +42,7 @@ function refO(object: any) {
       }
       return undefined;
     },
-    set(target, prop, value) {
+    set(target: Record<string, any>, prop: string, value: any) {
       if (!(prop in target)) {
         // TODO при присвоение, может потерять $parent
         const type = typeOf(value);
@@ -90,7 +90,7 @@ function refO(object: any) {
       }
       return false;
     },
-    deleteProperty(target, prop) {
+    deleteProperty(target: Record<string, any>, prop: string) {
       if (prop !== "$parent") {
         delete target[prop];
         return true;
@@ -101,8 +101,8 @@ function refO(object: any) {
     },
   });
 
-  Object.keys(object).forEach((key) => {
-    mainProxy[key] = object[key];
+  Object.keys(object).forEach((key: string) => {
+    (mainProxy as any)[key] = object[key];
   });
 
   return mainProxy;

--- a/src/package/reactive/refO.ts
+++ b/src/package/reactive/refO.ts
@@ -3,7 +3,7 @@ import { ref } from "./ref";
 import { typeOf } from "../usedFunction/typeOf";
 import { ProxyType } from "../reactive/type";
 import { refA } from "./refA";
-import { ReactiveParams } from "./type";
+//import { ReactiveParams } from "./type";
 
 function updated(target: Record<string, any>) {
   if (target.$parent.length > 0) {

--- a/src/package/reactive/type.ts
+++ b/src/package/reactive/type.ts
@@ -42,4 +42,15 @@ interface RefOProxy extends Proxy {
   $parent: Array<any>;
 };
 
-export { ProxyType, RefLProxy, RefProxy, PropsStartType, RefCProxy, RefOProxy, Proxy };
+interface RefAProxy extends Proxy {
+  parent: any[],
+  value: any,
+  render: any,
+  empty: boolean,
+  renderFunction: ((item?: any, index?: number) => any) | null,
+  forList: () => this,
+  parentNode: Record<string, any> | null,
+  keyNode: string
+}
+
+export { ProxyType, RefLProxy, RefProxy, PropsStartType, RefCProxy, RefOProxy, Proxy, RefAProxy };

--- a/src/package/reactive/type.ts
+++ b/src/package/reactive/type.ts
@@ -38,8 +38,15 @@ interface RefCProxy extends Proxy {
   value: () => any;
 };
 
-interface RefOProxy extends Proxy {
+
+type ReactiveParams = {
+  node: Comment | null,
+  nameValue: string
+};
+
+interface RefOProxy {
   $parent: Array<any>;
+  $reactiveParams: Array<ReactiveParams>;
 };
 
 interface RefAProxy extends Proxy {
@@ -53,4 +60,4 @@ interface RefAProxy extends Proxy {
   keyNode: string
 }
 
-export { ProxyType, RefLProxy, RefProxy, PropsStartType, RefCProxy, RefOProxy, Proxy, RefAProxy };
+export { ProxyType, RefLProxy, RefProxy, PropsStartType, RefCProxy, RefOProxy, Proxy, RefAProxy, ReactiveParams };

--- a/src/package/reactive/type.ts
+++ b/src/package/reactive/type.ts
@@ -17,32 +17,29 @@ enum PropsStartType {
   None = "None",
 }
 
-type RefLProxy = {
+interface Proxy {
+  type: ProxyType;
+  proxyType: ProxyType;
+}
+
+interface RefLProxy extends Proxy {
   parent: Array<any>;
   value: HTMLElement | null;
-  type: ProxyType;
-  proxyType: ProxyType;
 };
 
-type RefProxy = {
+interface RefProxy extends Proxy {
   parent: Array<any>;
   value: string | number | (() => any);
-  type: ProxyType;
-  proxyType: ProxyType;
   startType: PropsStartType;
 };
 
-type RefCProxy = {
+interface RefCProxy extends Proxy {
   parent: Array<any>;
   value: () => any;
-  type: ProxyType;
-  proxyType: ProxyType;
 };
 
-type RefOProxy = {
+interface RefOProxy extends Proxy {
   $parent: Array<any>;
-  type: ProxyType;
-  proxyType: ProxyType;
 };
 
-export { ProxyType, RefLProxy, RefProxy, PropsStartType, RefCProxy, RefOProxy };
+export { ProxyType, RefLProxy, RefProxy, PropsStartType, RefCProxy, RefOProxy, Proxy };

--- a/src/package/usedFunction/isEqual.ts
+++ b/src/package/usedFunction/isEqual.ts
@@ -1,6 +1,6 @@
 import { typeOf } from "./typeOf";
 
-function isEqualArray(ar1, ar2) {
+function isEqualArray(ar1: any, ar2: any) {
   if (ar1.length !== ar2.length) return false;
 
   for (let i = 0; i < ar1.length; i++) {
@@ -19,7 +19,7 @@ function isEqualArray(ar1, ar2) {
   return true;
 }
 
-function isEqual(object1, object2) {
+function isEqual(object1: any, object2: any) {
   const props1 = Object.getOwnPropertyNames(object1);
   const props2 = Object.getOwnPropertyNames(object2);
   if (props1.length !== props2.length) {

--- a/test/component-parser.test.ts
+++ b/test/component-parser.test.ts
@@ -1,0 +1,120 @@
+import {describe, expect, test} from '@jest/globals';
+import { parser } from "../src/package/dom/builder/index";
+import orve from "../src/index";
+
+const comp = function() {
+  return {
+    tag: "div",
+    child: ["hello"]
+  }
+} as any
+
+const comp1 : any = () => {
+  return {
+    tag: "div",
+    child: "hello"
+  }
+}
+
+function t(object: any) {
+  expect(object["tag"]).not.toBeUndefined();
+  expect(object["type"]).toBe("Component");
+  expect(Array.isArray(object["child"])).toBe(true);
+
+  if (Array.isArray(object["child"])) {
+    expect(object["child"][0]["type"]).toBe("Static");
+    expect(object["child"][0]["value"]).not.toBeUndefined();
+    expect(object["child"][0]["value"]).toBe("hello");
+  }
+}
+
+describe('Hello Component without mounted', () => {
+  test('build comp-1', () => {
+    const object = parser(comp);
+    t(object);
+  });
+  test('build comp-2', () => {
+    const object = parser(comp1);
+    t(object);
+  });
+});
+
+
+// Check parse app with Layer 
+const Component1 = function() {
+  return {
+    tag: Layer,
+    child: ["Hello"]
+  }
+}
+
+const Layer = function({ children }: { children: any }) {
+  return {
+    tag: "div",
+    child: [
+      children,
+      "World"
+    ]
+  }
+}
+// ------
+
+
+// check parse app with Layer and Props
+
+function Layer1({ children, classes } : { children: any, classes: any }) {
+  return {
+    tag: "div",
+    props: {
+      class: classes
+    },
+    child: [
+      children[0] + " 1"
+    ]
+  }
+}
+
+function Component2() {
+  return {
+    tag: Layer1,
+    props: {
+      id: 123,
+      classes: "test"
+    },
+    child: "test"
+  }
+}
+
+// -----
+
+
+describe('Component with layer', () => {
+  test("Check parse app with Layer", () => {
+    const app = parser(Component1);
+
+    expect(Array.isArray(app?.child)).toBe(true);
+
+    expect(app?.child.length).toBe(2);
+
+    app?.child.forEach((e: any) => {
+      expect(e.type).toBe("Static");
+    });
+
+    expect(app?.child[0].value).toBe("Hello");
+    expect(app?.child[1].value).toBe("World");
+  })
+
+  test("check parse app with Layer and Props", () => {
+    const app = parser(Component2);
+
+    expect(app?.props).toBeDefined();
+    expect(app?.props?.class).toBeDefined();
+    expect(app?.props?.class).toBe("test");
+
+    expect(app?.child).toBeDefined();
+
+    expect(app?.child.length).toBe(1);
+
+    expect(app?.child[0].value).toBe("test 1");
+  })
+});

--- a/test/component.test.ts
+++ b/test/component.test.ts
@@ -15,7 +15,7 @@ const comp1 : any = () => {
   }
 }
 
-function t(object) {
+function t(object: any) {
   expect(object["tag"]).not.toBeUndefined();
   expect(object["type"]).toBe("Component");
   expect(Array.isArray(object["child"])).toBe(true);

--- a/test/component.test.ts
+++ b/test/component.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, test} from '@jest/globals';
 import { parser } from "../src/package/dom/builder/index";
+import orve from "../src/index";
 
 const comp = function() {
   return {
@@ -36,4 +37,84 @@ describe('Hello Component without mounted', () => {
     const object = parser(comp1);
     t(object);
   });
+});
+
+
+// Check parse app with Layer 
+const Component1 = function() {
+  return {
+    tag: Layer,
+    child: ["Hello"]
+  }
+}
+
+const Layer = function({ children }: { children: any }) {
+  return {
+    tag: "div",
+    child: [
+      children,
+      "World"
+    ]
+  }
+}
+// ------
+
+
+// check parse app with Layer and Props
+
+function Layer1({ children, classes } : { children: any, classes: any }) {
+  return {
+    tag: "div",
+    props: {
+      class: classes
+    },
+    child: [
+      children[0] + " 1"
+    ]
+  }
+}
+
+function Component2() {
+  return {
+    tag: Layer1,
+    props: {
+      id: 123,
+      classes: "test"
+    },
+    child: "test"
+  }
+}
+
+// -----
+
+
+describe('Component with layer', () => {
+  test("Check parse app with Layer", () => {
+    const app = parser(Component1);
+
+    expect(Array.isArray(app?.child)).toBe(true);
+
+    expect(app?.child.length).toBe(2);
+
+    app?.child.forEach((e: any) => {
+      expect(e.type).toBe("Static");
+    });
+
+    expect(app?.child[0].value).toBe("Hello");
+    expect(app?.child[1].value).toBe("World");
+  })
+
+  test("check parse app with Layer and Props", () => {
+    const app = parser(Component2);
+
+    expect(app?.props).toBeDefined();
+    expect(app?.props?.class).toBeDefined();
+    expect(app?.props?.class).toBe("test");
+
+    expect(app?.child).toBeDefined();
+
+    expect(app?.child.length).toBe(1);
+
+    expect(app?.child[0].value).toBe("test 1");
+  })
 });

--- a/test/component.test.ts
+++ b/test/component.test.ts
@@ -1,120 +1,42 @@
-import {describe, expect, test} from '@jest/globals';
-import { parser } from "../src/package/dom/builder/index";
-import orve from "../src/index";
+import { beforeAll, describe, expect, test} from '@jest/globals';
+import { Node, createApp } from "../src/index";
+import { afterEach, beforeEach } from 'node:test';
 
-const comp = function() {
-  return {
-    tag: "div",
-    child: ["hello"]
+const Components = [
+  () => {
+    return (
+      Node("div", { id: "block" }, "Hello world")
+    )
+  },
+  () => {
+    return (
+      Node("div", { id: "block" }, Node("div", {}, "Hello ", "world"))
+    )
   }
-} as any
+];
 
-const comp1 : any = () => {
-  return {
-    tag: "div",
-    child: "hello"
-  }
-}
+describe("create app with function jsx", () => {
+  test("hello world", () => {
+    document.body.innerHTML = "<div id='app'></div>";
+    createApp(Components[0])?.mount("#app");
 
-function t(object: any) {
-  expect(object["tag"]).not.toBeUndefined();
-  expect(object["type"]).toBe("Component");
-  expect(Array.isArray(object["child"])).toBe(true);
+    const item = document.getElementById("block");
 
-  if (Array.isArray(object["child"])) {
-    expect(object["child"][0]["type"]).toBe("Static");
-    expect(object["child"][0]["value"]).not.toBeUndefined();
-    expect(object["child"][0]["value"]).toBe("hello");
-  }
-}
-
-describe('Hello Component without mounted', () => {
-  test('build comp-1', () => {
-    const object = parser(comp);
-    t(object);
-  });
-  test('build comp-2', () => {
-    const object = parser(comp1);
-    t(object);
-  });
-});
-
-
-// Check parse app with Layer 
-const Component1 = function() {
-  return {
-    tag: Layer,
-    child: ["Hello"]
-  }
-}
-
-const Layer = function({ children }: { children: any }) {
-  return {
-    tag: "div",
-    child: [
-      children,
-      "World"
-    ]
-  }
-}
-// ------
-
-
-// check parse app with Layer and Props
-
-function Layer1({ children, classes } : { children: any, classes: any }) {
-  return {
-    tag: "div",
-    props: {
-      class: classes
-    },
-    child: [
-      children[0] + " 1"
-    ]
-  }
-}
-
-function Component2() {
-  return {
-    tag: Layer1,
-    props: {
-      id: 123,
-      classes: "test"
-    },
-    child: "test"
-  }
-}
-
-// -----
-
-
-describe('Component with layer', () => {
-  test("Check parse app with Layer", () => {
-    const app = parser(Component1);
-
-    expect(Array.isArray(app?.child)).toBe(true);
-
-    expect(app?.child.length).toBe(2);
-
-    app?.child.forEach((e: any) => {
-      expect(e.type).toBe("Static");
-    });
-
-    expect(app?.child[0].value).toBe("Hello");
-    expect(app?.child[1].value).toBe("World");
+    expect(item).toBeDefined();
+    expect(item?.innerHTML).toBe("Hello world");
   })
 
-  test("check parse app with Layer and Props", () => {
-    const app = parser(Component2);
+  test("hello world with 2 div element", () => {
+    document.body.innerHTML = "<div id='app'></div>";
+    createApp(Components[1])?.mount("#app");
 
-    expect(app?.props).toBeDefined();
-    expect(app?.props?.class).toBeDefined();
-    expect(app?.props?.class).toBe("test");
+    const item = document.getElementById("block");
 
-    expect(app?.child).toBeDefined();
+    expect(item).toBeDefined();
 
-    expect(app?.child.length).toBe(1);
+    const divInner = item?.firstElementChild;
 
-    expect(app?.child[0].value).toBe("test 1");
+    expect(divInner).toBeDefined();
+    expect(divInner?.innerHTML).toBe("Hello world")
   })
-});
+})

--- a/test/layer.test.ts
+++ b/test/layer.test.ts
@@ -1,11 +1,11 @@
 import {describe, expect, test} from '@jest/globals';
 import { createApp } from "../src/index";
 
-const layer = function({children, ...props}) {
+const layer = function({children, ...props}: {children: any}) {
   return {
     tag: "div",
     props: props,
-    child: children
+    child: children as any[]
   }
 }
 
@@ -41,7 +41,7 @@ describe("Layer test - 1", () => {
 });
 
 
-const layer2 = function({children, ...props}) {
+const layer2 = function({children, ...props}: {children: any}) {
   return {
     tag: "div",
     props: props,
@@ -49,7 +49,7 @@ const layer2 = function({children, ...props}) {
   }
 }
 
-const layer1 = function({children, ...props}) {
+const layer1 = function({children, ...props}: { children: any }) {
   return {
     tag: layer2,
     props: props,
@@ -73,7 +73,7 @@ describe("Layer in layer", () => {
   test("created and mounted", () => {
     body.innerHTML = "<div id='app'></div>";
     const app = createApp(mainComponent1)
-    app.mount("#app");
+    app?.mount("#app");
     expect(body.childNodes.length).not.toBe(0);
   })
   test("check component", () => {

--- a/test/oHtml.test.ts
+++ b/test/oHtml.test.ts
@@ -14,7 +14,7 @@ document.body.innerHTML = `<div id="app"></div>`
 describe("Check o-html prop", () => {
   test("create-app", () => {
     const app = createApp(component);
-    app.mount("#app");
+    app?.mount("#app");
     expect(document.querySelector("div")?.innerHTML).toBe("test123");
   })
 })

--- a/test/ref.test.ts
+++ b/test/ref.test.ts
@@ -21,7 +21,7 @@ describe("Ref string child", () => {
       }
     }
     const app = createApp({App: component});
-    app.mount("#app");
+    app?.mount("#app");
   })
   test("Check first draw", () => {
     expect(body.querySelector("div")?.innerHTML).toBe("123");
@@ -51,7 +51,7 @@ describe("Ref number child", () => {
       }
     }
     const app = createApp({App: component});
-    app.mount("#app");
+    app?.mount("#app");
   })
   test("Check first draw", () => {
     expect(body.querySelector("div")?.innerHTML).toBe("1");
@@ -83,7 +83,7 @@ describe("Ref string, number props", () => {
       }
     }
     const app = createApp({App: component});
-    app.mount("#app");
+    app?.mount("#app");
   })
   test("Check first draw", () => {
     expect(body.querySelector("div")?.innerHTML).toBe("text");

--- a/test/refA.test.ts
+++ b/test/refA.test.ts
@@ -12,19 +12,23 @@ function comp() {
       "class": "my-block",
       "@click": () => {r.value[0] = {id:2};}
     },
-    child: r.forList((e, i) => {
+    child: r.forList((e: any, i: number) => {
       // console.log(e, i);
+      return {
+        tag: "div",
+        child: e.id
+      }
     })
   }
 }
 
 describe("test refA", () => {
   test('should first', () => {
-    const one = ref(new Array(3).fill(0).map((e, i) => ({id: i +1, v: null})));
+    const one = ref(new Array(3).fill(0).map((e: any, i) => ({id: i +1, v: null})));
     const second = ref([]);
 
-    one.forList((e) => { return { tag: "div", child: e.id } });
-    second.forList((e) => e);
+    one.forList((e: Record<string, any>) => { return { tag: "div", child: e.id } });
+    second.forList((e: any) => e);
 
     one.value[0] = { id:1, v: 1 };
     second.value.push(one.value.slice(0));
@@ -40,7 +44,7 @@ describe("test refA", () => {
 
   test("check forList", () => {
     document.body.innerHTML = `<div id = "app"></div>`;
-    createApp(comp).mount("#app");
+    createApp(comp)?.mount("#app");
     (document.body.querySelector(".my-block") as any).click();
   })
 })

--- a/test/refC.test.ts
+++ b/test/refC.test.ts
@@ -46,8 +46,10 @@ describe("refC test", () => {
         ]
       }
     }
-    const app = createApp({App: component});
-    app.mount("#app");
+    const app = createApp(component);
+    if (app !== undefined) {
+      app.mount("#app");
+    }
     const div = document.querySelector("div");
     expect(div?.querySelector("#comp")?.innerHTML).toMatch(/comp-1/);
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,12 @@
     "module": "esnext",
     "moduleResolution": "node",
     "sourceMap": false,
-    "strict": false,
+    "strict": true,
     "esModuleInterop": true,
     "newLine": "LF",
     "removeComments": false,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noImplicitThis": false
   },
   "include": ["./src/**/*"],
   "exclude": [


### PR DESCRIPTION
### EN
* User can get context from `orve` directly
* Rewritten types
* Strict mode enabled (but there is a lot of `any` type in the code)
* Started work with the refO function.
* The refA function now supports `pop shift unshift splice`, the ability to reassign a new array
* [BETA] Added new function `createAppRoot`. It will allow you not to write in each component `import orve from "orve"`

### RU
* Пользователь может получить контекст из `orve` напрямую
* Переписаны типы
* Включен строгий режим (но в коде много типа `any`)
* Начата работа с функцией refO.
* Функция refA теперь поддерживает `pop shift unshift splice`, возможность переназначить новый массив
* [BETA] Добавлена новая функция `createAppRoot`. Она позволит вам не писать в каждом компоненте `import orve from "orve"`


### createAppRoot

```
// index.js

import orve from "orve"; 
import App from "./App";

orve.createAppRoot(<App />).mount("#app");
```
then you can write component without  `import orve from "orve"`